### PR TITLE
Front End sanitation and minor incremental changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,128 +2,127 @@
 <html>
   <head>
     <meta charset='utf-8'>
+    <title>No fucks to give</title>
+
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <link href='https://fonts.googleapis.com/css?family=Chivo:900' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
-    <link rel="stylesheet" type="text/css" href="stylesheets/pygment_trac.css" media="screen">
-    <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Chivo:900" rel="stylesheet">
+    <link rel="stylesheet" href="stylesheets/stylesheet.css">
+
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <title>No fucks to give</title>
   </head>
 
   <body>
     <div id="container">
-      <div class="inner">
 
         <header>
           <h1>This is how many fucks I have to give.</h1>
         </header>
         <hr>
 
-        <section id="main_content" style="text-align: center;">
-	        
-	        <a href="./index.html" style="background-color: white; color: #000000; padding: 10px; border: 1px solid #8c8a8a;">Recalculate</a>
-	        <br>
-			<br>
+        <section id="main_content">
+
+	        <a href="./index.html" class="reload">Recalculate</a>
+
+          <!--ALL HAIL GOATSE-->
+
+      		<!--
+      		* * * * * * * * * * * * * * * * * * * * * * * * *
+      		*                                               *
+      		* /     \             \            /    \       *
+      		*|       |             \          |      |      *
+      		*|       `.             |         |       :     *
+      		*`        |             |        \|       |     *
+      		* \       | /       /  \\\   ____ \\       :    *
+      		*  \      \/   ___~~          ~____| \     |    *
+      		*   \      \__~                    ~__\    |    *
+      		*    \_     \        _.______  .______\|   |    *
+      		*      \     \______// _ ___ _ (_(__>  \   |    *
+      		*       \   .  C ___)  ______ (_(____>  |  /    *
+      		*       /\ |   C ____)/      \ (_____>  |_/     *
+      		*      / /\|   C_____)       |  (___>   /  \    *
+      		*     |   (   _C_____)\______/  // _/ /     \   *
+      		*     |    \  |__   \\_________// (__/       |  *
+      		*    | \    \____)   `____  ___'             |  *
+      		*    |  \_          ___\       /_          _/ | *
+      		*   |              /    |     |  \            | *
+      		*   |             |    /       \  \           | *
+      		*   |          / /    |         |  \           |*
+      		*   |         / /      \__/\___/    |          |*
+      		*  |           /        |    |       |         |*
+      		*  |          |         |    |       |         |*
+      		* * * * * * * * * * * * * * * * * * * * * * * * *
+      		-->
 
 
-		<!--
-		* * * * * * * * * * * * * * * * * * * * * * * * *
-		*                                               *
-		* /     \             \            /    \       *
-		*|       |             \          |      |      *
-		*|       `.             |         |       :     *
-		*`        |             |        \|       |     *
-		* \       | /       /  \\\   ____ \\       :    *
-		*  \      \/   ___~~          ~____| \     |    *
-		*   \      \__~                    ~__\    |    *
-		*    \_     \        _.______  .______\|   |    *
-		*      \     \______// _ ___ _ (_(__>  \   |    *
-		*       \   .  C ___)  ______ (_(____>  |  /    *
-		*       /\ |   C ____)/      \ (_____>  |_/     *
-		*      / /\|   C_____)       |  (___>   /  \    *
-		*     |   (   _C_____)\______/  // _/ /     \   *
-		*     |    \  |__   \\_________// (__/       |  *
-		*    | \    \____)   `____  ___'             |  *
-		*    |  \_          ___\       /_          _/ | *
-		*   |              /    |     |  \            | *
-		*   |             |    /       \  \           | *
-		*   |          / /    |         |  \           |*
-		*   |         / /      \__/\___/    |          |*
-		*  |           /        |    |       |         |*
-		*  |          |         |    |       |         |*
-		* * * * * * * * * * * * * * * * * * * * * * * * *
-		-->
+      		<script>
+      		<!--
+
+      			/*
+      			Random Image Script- By JavaScript Kit (http://www.javascriptkit.com)
+      			Over 400+ free JavaScripts here!
+      			Keep this notice intact please
+      			*/
+
+      			(function (){
+      				var myimages = [
+      					"images/fucks/music.jpg",
+      					"images/fucks/batman.gif",
+      					"images/fucks/norris.jpg",
+      					"images/fucks/anakin.jpg",
+      					"images/fucks/box.jpg",
+      					"images/fucks/524.gif",
+      					"images/fucks/sagan.gif",
+      					"images/fucks/dancey.gif",
+      					"images/fucks/colbert.gif",
+      					"images/fucks/space.gif",
+      					"images/fucks/meter.gif",
+      					"images/fucks/owl.jpg",
+      					"images/fucks/frog.jpg",
+      					"images/fucks/soupman.jpg",
+      					"images/fucks/kitten.jpg",
+      					"images/fucks/news.jpg",
+      					"images/fucks/kpop.gif",
+      					"images/fucks/windows.gif",
+      					"images/fucks/barren.jpg",
+      					"images/fucks/alice.gif",
+      					"images/fucks/there-goes-my-last-fuck.gif",
+      					"images/fucks/one-fuck-left-to-give.jpg",
+      					"images/fucks/number-of-people.gif",
+      					"images/fucks/gone.jpg",
+      					"images/fucks/not_a_fuck.jpg",
+      					"images/fucks/morgan.jpg",
+      					"images/fucks/crab.gif",
+      					"images/fucks/who.gif",
+      					"images/fucks/elmo.gif",
+      					"images/fucks/spongebob.jpg",
+      					"images/fucks/rick.jpg",
+      					"images/fucks/ceiling-cat.jpg",
+      					"images/fucks/figure.jpg",
+      					"images/fucks/data.jpg",
+      					"images/fucks/count.jpg",
+      					"images/fucks/hotline.png",
+      					"images/fucks/calc-cat.jpg",
+      					"images/fucks/paper.jpg",
+      					"images/fucks/zero.jpg",
+      					"images/fucks/math.jpg",
+      					"images/fucks/panda.jpg",
+      					"images/fucks/panda.gif",
+      					"images/fucks/gangnam.gif",
+      					"images/fucks/f.jpg",
+      					"images/fucks/chicken.jpg",
+      					"images/fucks/bucket.png",
+      					"images/fucks/seen-my-fuck.gif"
+      				];
+      				var ry=Math.floor(Math.random()*myimages.length)
+      				document.write('<img src="'+myimages[ry]+'" href="/index.html">')
+      			})();
+      			//-->
+      		</script>
 
 
-		<script language="JavaScript">
-		<!--
-
-			/*
-			Random Image Script- By JavaScript Kit (http://www.javascriptkit.com)
-			Over 400+ free JavaScripts here!
-			Keep this notice intact please
-			*/
-
-			(function (){
-				var myimages = [
-					"images/fucks/music.jpg",
-					"images/fucks/batman.gif",
-					"images/fucks/norris.jpg",
-					"images/fucks/anakin.jpg",
-					"images/fucks/box.jpg",
-					"images/fucks/524.gif",
-					"images/fucks/sagan.gif",
-					"images/fucks/dancey.gif",
-					"images/fucks/colbert.gif",
-					"images/fucks/space.gif",
-					"images/fucks/meter.gif",
-					"images/fucks/owl.jpg",
-					"images/fucks/frog.jpg",
-					"images/fucks/soupman.jpg",
-					"images/fucks/kitten.jpg",
-					"images/fucks/news.jpg",
-					"images/fucks/kpop.gif",
-					"images/fucks/windows.gif",
-					"images/fucks/barren.jpg",
-					"images/fucks/alice.gif",
-					"images/fucks/there-goes-my-last-fuck.gif",
-					"images/fucks/one-fuck-left-to-give.jpg",
-					"images/fucks/number-of-people.gif",
-					"images/fucks/gone.jpg",
-					"images/fucks/not_a_fuck.jpg",
-					"images/fucks/morgan.jpg",
-					"images/fucks/crab.gif",
-					"images/fucks/who.gif",
-					"images/fucks/elmo.gif",
-					"images/fucks/spongebob.jpg",
-					"images/fucks/rick.jpg",
-					"images/fucks/ceiling-cat.jpg",
-					"images/fucks/figure.jpg",
-					"images/fucks/data.jpg",
-					"images/fucks/count.jpg",
-					"images/fucks/hotline.png",
-					"images/fucks/calc-cat.jpg",
-					"images/fucks/paper.jpg",
-					"images/fucks/zero.jpg",
-					"images/fucks/math.jpg",
-					"images/fucks/panda.jpg",
-					"images/fucks/panda.gif",
-					"images/fucks/gangnam.gif",
-					"images/fucks/f.jpg",
-					"images/fucks/chicken.jpg",
-					"images/fucks/bucket.png",
-					"images/fucks/seen-my-fuck.gif"
-				];
-				var ry=Math.floor(Math.random()*myimages.length)
-				document.write('<img src="'+myimages[ry]+'" border="0" href="/index.html">')
-			})();
-			//-->
-		</script>
-
-				
 
         </section>
 
@@ -131,19 +130,17 @@
           This site is maintained by <a href="https://twitter.com/snipeyhead">@snipeyhead</a>. Hit reload to see a new "no fucks" meme. Fork it <a href="https://github.com/snipe/nofuckstogive.today">here</a>. Pull requests welcome :)
         </footer>
 
-
-      </div>
     </div>
 
     <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-55904612-1', 'auto');
-  ga('send', 'pageview');
+      ga('create', 'UA-55904612-1', 'auto');
+      ga('send', 'pageview');
 
-</script>
+    </script>
   </body>
 </html>

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -1,4 +1,4 @@
-/* http://meyerweb.com/eric/tools/css/reset/ 
+/* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
 */
@@ -11,8 +11,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
 	margin: 0;
@@ -23,7 +23,7 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
@@ -49,8 +49,8 @@ table {
 /* LAYOUT STYLES */
 body {
   font-size: 1em;
-  line-height: 1.5; 
-  background: #e7e7e7 url(../images/body-bg.png) 0 0 repeat;
+  line-height: 1.5;
+  background: #e7e7e7 url(../images/highlight-bg.jpg) 50% 0 no-repeat;
   font-family: 'Helvetica Neue', Helvetica, Arial, serif;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
   color: #6d6d6d;
@@ -85,17 +85,26 @@ header h2 {
 }
 
 #container {
-  background: transparent url(../images/highlight-bg.jpg) 50% 0 no-repeat;
   min-height: 595px;
+	max-width: 620px;
+	margin: 0 auto;
 }
 
-.inner {
-  width: 620px;
-  margin: 0 auto;
+#container > section {
+	text-align: center;
 }
 
-#container .inner img {
+/*#container > section:before,
+#container > section:after {
+	content: '';
+	display: table;
+	clear: both;
+}*/
+
+#container img {
   max-width: 100%;
+	display: inline-block;
+	margin-top: 24px;
 }
 
 #downloads {
@@ -104,7 +113,7 @@ header h2 {
 
 a.button {
   -moz-border-radius: 30px;
-  -webkit-border-radius: 30px;                     
+  -webkit-border-radius: 30px;
   border-radius: 30px;
   border-top: solid 1px #cbcbcb;
   border-left: solid 1px #b7b7b7;
@@ -118,7 +127,7 @@ a.button {
   display: block;
   float: left;
   width: 179px;
-  margin-right: 14px;  
+  margin-right: 14px;
   background: #fdfdfd; /* Old browsers */
   background: -moz-linear-gradient(top,  #fdfdfd 0%, #f2f2f2 100%); /* FF3.6+ */
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#fdfdfd), color-stop(100%,#f2f2f2)); /* Chrome,Safari4+ */
@@ -150,6 +159,18 @@ a.button span {
   padding-left: 50px;
   display: block;
   height: 23px;
+}
+
+.reload {
+	background-color: white;
+	color: #000000;
+	padding: 10px;
+	border: 1px solid #8c8a8a;
+}
+
+.reload:after {
+	content: '\A';
+	white-space: pre;
 }
 
 #download-zip span {
@@ -227,14 +248,14 @@ th {
 
 td {
   border: 1px solid #ebebeb;
-  text-align: center; 
+  text-align: center;
   font-weight: 300;
 }
 
 form {
   background: #f2f2f2;
   padding: 20px;
-  
+
 }
 
 
@@ -242,43 +263,43 @@ form {
 
 h1 {
   font-size: 32px;
-} 
+}
 
 h2 {
   font-size: 22px;
   font-weight: bold;
   color: #303030;
   margin-bottom: 8px;
-} 
+}
 
 h3 {
   color: #d5000d;
   font-size: 18px;
   font-weight: bold;
   margin-bottom: 8px;
-} 
- 
+}
+
 h4 {
   font-size: 16px;
   color: #303030;
   font-weight: bold;
-} 
+}
 
 h5 {
   font-size: 1em;
   color: #303030;
-} 
+}
 
 h6 {
   font-size: .8em;
   color: #303030;
-} 
+}
 
 p {
   font-weight: 300;
   margin-bottom: 20px;
 }
- 
+
 a {
   text-decoration: none;
 }
@@ -358,9 +379,8 @@ footer a:hover {
   #download-zip, #download-tar-gz {
     display: none;
   }
-  .inner {
+  .container {
     width: 94%;
-    margin: 0 auto;
   }
 }
 


### PR DESCRIPTION
The following fucks were given:
- Improved white spacing on certain pieces of code so they're indented properly
- Unlinked `print.css` and `pygment-trac.css`; not necessary and less requests to make.
- Removed `language=Javascript"` in the `script` tag. Not needed in HTML5.
- Removed use of `br` tags, not a good way of spacing and uses CSS instead.
- Removed inline `style` attributes and placed them in `stylesheet.css` instead.
- Button has now magically centered itself(???); wasn't actually centred before.
- `.inner` div has been removed; uneccessary and `.container` serves the same purpose.
- Added `<meta name="viewport">` tag; the site can now be viewed appropriately on all devices as it already has responsive styles as a default.
- **ALL HAIL GOATSE**
